### PR TITLE
Fix -H and -L rolls

### DIFF
--- a/lib/src/d20.dart
+++ b/lib/src/d20.dart
@@ -7,6 +7,7 @@
 /// ```
 
 import 'dart:math';
+import 'package:collection/collection.dart';
 import 'package:math_expressions/math_expressions.dart';
 import 'roll_result.dart';
 import 'roll_statistics.dart';
@@ -45,12 +46,14 @@ class D20 {
         .toList();
     final lowestHighest = match[3];
 
-    var sum = results.fold(0, (int sum, int roll) => sum + roll);
+    int finalResult;
 
     if (lowestHighest == '-l') {
-      sum -= results.fold<int>(faces, min);
+      finalResult = results.min;
     } else if (lowestHighest == '-h') {
-      sum -= results.fold<int>(0, max);
+      finalResult = results.max;
+    } else {
+      finalResult = results.fold(0, (int sum, int roll) => sum + roll);
     }
 
     return RollResult(
@@ -58,7 +61,7 @@ class D20 {
       faces: faces,
       numberOfRolls: numberOfRolls,
       results: results,
-      finalResult: sum,
+      finalResult: finalResult,
     );
   }
 

--- a/lib/src/d20.dart
+++ b/lib/src/d20.dart
@@ -5,12 +5,12 @@
 /// ```
 /// import 'package:d20/d20.dart';
 /// ```
-
 import 'dart:math';
+
 import 'package:collection/collection.dart';
 import 'package:math_expressions/math_expressions.dart';
-import 'roll_result.dart';
-import 'roll_statistics.dart';
+
+import '../d20.dart';
 
 final RegExp _singleDiceRegExp = RegExp(r'(\d+)?d(\d+)(-[l|h])?');
 
@@ -125,6 +125,6 @@ class D20 {
         // ignore: avoid_as
         .evaluate(EvaluationType.REAL, _context) as double;
 
-    return exactResult.round();
+    return exactResult.ceil();
   }
 }


### PR DESCRIPTION
I noticed this package is not maintained anymore, but I'm using it now so I thought to contribute by fixing these errors. 🙂

- More than two dices didn't work when using -L or -H
  Expressions like "10d10-L" summed some of the values instead of returning the lowest of all values.

- L and H were inverted
  When the results were [1, 2], -L returned 2 and -H returned 1.